### PR TITLE
Really version 1.03 and PHP7 fixes

### DIFF
--- a/posts.php
+++ b/posts.php
@@ -38,6 +38,13 @@ add_shortcode( 'postlist', 'dirtysuds_postlist' );
 function dirtysuds_postlist( $atts ) {
 	global $wpdb;
 
+	if ( !is_array( $atts ) ) {
+		if ( empty( $atts ) ) {
+			$atts = array();
+		} else {
+			$atts = array( $atts );
+		}
+	}
 
 	$embed = get_transient( 'dirtysuds_postlist' . implode($atts) );
 	if( $embed ) return $embed;

--- a/posts.php
+++ b/posts.php
@@ -7,7 +7,7 @@ Author: Pat Hawks
 Author URI: http://pathawks.com
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Version: 1.03
+Version: 1.04
 
   Copyright 2014 Pat Hawks  (email : pat@pathawks.com)
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Tags: plugins, wordpress, shortcode, homepage
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 3.5
-Tested up to: 4.0
-Stable tag: 1.03
+Tested up to: 5.0.12
+Stable tag: 1.04
 
 Adds shortcode `[postlist]` for embedding a list of posts into a page
 
@@ -30,6 +30,9 @@ Please open a pull request on [Github](https://github.com/pathawks/postlist)
 
 
 == Changelog ==
+
+= 1.04 20210620 =
+* Fixed warnings with PHP7.
 
 = 1.03 20141011 =
 * Bugfix


### PR DESCRIPTION
The version in current master is actually 1.02. I've fetched the version from https://downloads.wordpress.org/plugin/dirtysuds-postlist.1.03.zip .

The next problem are warning about `$atts` to be an array from PHP7. Fixed.
